### PR TITLE
Add Comic Sans CDN to Display Comic Sans Font on Mobile Browsers

### DIFF
--- a/site.css
+++ b/site.css
@@ -1,3 +1,5 @@
+@import url('http://fonts.cdnfonts.com/css/comic-sans');
+
 html {
     font-size: 14px;
   }


### PR DESCRIPTION
This will allow comic sans to be displayed for mobile browsers